### PR TITLE
fix: main and master are not valid on a branch with another name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["hatchling"]
 [bumpver]
 commit = true
 commit_message = "bump version to {new_version}"
-current_version = "0.18.3"
+current_version = "0.18.4"
 push = true
 tag = true
 tag_message = "v{new_version}"

--- a/src/falco/__about__.py
+++ b/src/falco/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Tobi DEGNON <tobidegnon@proton.me>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.18.3"
+__version__ = "0.18.4"

--- a/src/falco/commands/start_project.py
+++ b/src/falco/commands/start_project.py
@@ -197,7 +197,7 @@ def resolve_blueprint(blueprint: str, *, use_local: bool = False) -> tuple[str, 
             raise cappa.Exit(msg, code=1)
 
     result = subprocess.run(
-        ["git", "ls-remote", repo, "main", "master"],
+        ["git", "ls-remote", repo, "HEAD"],
         capture_output=True,
         text=True,
         check=False,


### PR DESCRIPTION
The start-project fails to resolve the blueprint, when on a branch, let's say branch-a, on that branch the ls-remote with main and master as filters will return an empty output. HEAD seems to be always available, at least that I think, so let's try with this for now